### PR TITLE
⬆️ tf: Update hashicorp/aws provider to ~> 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ module "api_gateway" {
 | Name | Version |
 | ------------------------------------------------------------------------ | -------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement_aws) | ~> 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement_aws) | ~> 6.0 |
 
 ### Providers
 

--- a/examples/account-logs/versions.tf
+++ b/examples/account-logs/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/oidc-auth/main.tf
+++ b/examples/oidc-auth/main.tf
@@ -116,7 +116,7 @@ module "label" {
 # Public Lambda function (no authorization)
 module "lambda_public" {
   source  = "bendoerr-terraform-modules/lambda/aws"
-  version = "0.1.2"
+  version = "0.2.0"
 
   context     = module.context
   name        = "${module.label.id}-public"
@@ -131,7 +131,7 @@ module "lambda_public" {
 # Protected Lambda function (requires authorization)
 module "lambda_protected" {
   source  = "bendoerr-terraform-modules/lambda/aws"
-  version = "0.1.2"
+  version = "0.2.0"
 
   context     = module.context
   name        = "${module.label.id}-protected"

--- a/examples/oidc-auth/versions.tf
+++ b/examples/oidc-auth/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -55,7 +55,7 @@ module "this" {
 module "lambda" {
   source  = "bendoerr-terraform-modules/lambda/aws"
   context = module.context
-  version = "0.1.2"
+  version = "0.2.0"
 
   name        = "simple"
   description = "Example Lambda Handler"

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/modules/account-logs/README.md
+++ b/modules/account-logs/README.md
@@ -28,7 +28,7 @@ module "api_gateway_account" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement_aws) | ~> 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement_aws) | ~> 6.0 |
 
 ### Providers
 

--- a/modules/account-logs/versions.tf
+++ b/modules/account-logs/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/modules/custom-domain/README.md
+++ b/modules/custom-domain/README.md
@@ -21,7 +21,7 @@ The module is designed as a submodule for the main API Gateway module but can al
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement_aws) | ~> 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement_aws) | ~> 6.0 |
 
 ### Providers
 

--- a/modules/custom-domain/versions.tf
+++ b/modules/custom-domain/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/modules/oidc-authorizer/README.md
+++ b/modules/oidc-authorizer/README.md
@@ -45,7 +45,7 @@ module "oidc_authorizer" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement_aws) | ~> 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement_aws) | ~> 6.0 |
 | <a name="requirement_github"></a> [github](#requirement_github) | ~> 6.0 |
 | <a name="requirement_http"></a> [http](#requirement_http) | ~> 3.0 |
 | <a name="requirement_local"></a> [local](#requirement_local) | 2.5.2 |

--- a/modules/oidc-authorizer/main.tf
+++ b/modules/oidc-authorizer/main.tf
@@ -7,7 +7,7 @@ module "label" {
 
 module "oidc_authorizer_lambda" {
   source  = "bendoerr-terraform-modules/lambda/aws"
-  version = "0.1.2"
+  version = "0.2.0"
 
   context = var.context
   name    = var.name

--- a/modules/oidc-authorizer/versions.tf
+++ b/modules/oidc-authorizer/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
     github = {
       source  = "integrations/github"

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     # Use a v5.x.x version of the AWS provider
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the required AWS provider version to support the latest 6.x.x releases.
  - Upgraded several Terraform module versions to enhance compatibility and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->