### PR TITLE
✨ custom-domain: Add endpoint_access_mode for enhanced security policies

### DIFF
--- a/modules/custom-domain/README.md
+++ b/modules/custom-domain/README.md
@@ -27,7 +27,7 @@ The module is designed as a submodule for the main API Gateway module but can al
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider_aws) | 5.96.0 |
+| <a name="provider_aws"></a> [aws](#provider_aws) | 6.0.0 |
 
 ### Modules
 
@@ -50,13 +50,14 @@ The module is designed as a submodule for the main API Gateway module but can al
 | <a name="input_base_path"></a> [base_path](#input_base_path) | Base path to map the API under the domain (empty string for root) | `string` | `""` | no |
 | <a name="input_certificate_arn"></a> [certificate_arn](#input_certificate_arn) | ARN of the ACM certificate to use for the custom domain | `string` | `null` | no |
 | <a name="input_certificate_type"></a> [certificate_type](#input_certificate_type) | Type of certificate for the custom domain. Valid values: EDGE, REGIONAL | `string` | `"REGIONAL"` | no |
-| <a name="input_context"></a> [context](#input_context) | Shared context from the 'bendoerr-terraform-modules/terraform-null-context' module. | <pre>object({<br> attributes = list(string)<br> dns_namespace = string<br> environment = string<br> instance = string<br> instance_short = string<br> namespace = string<br> region = string<br> region_short = string<br> role = string<br> role_short = string<br> project = string<br> tags = map(string)<br> })</pre> | n/a | yes |
+| <a name="input_context"></a> [context](#input_context) | Shared context from the 'bendoerr-terraform-modules/terraform-null-context' module. | <pre>object({<br/> attributes = list(string)<br/> dns_namespace = string<br/> environment = string<br/> instance = string<br/> instance_short = string<br/> namespace = string<br/> region = string<br/> region_short = string<br/> role = string<br/> role_short = string<br/> project = string<br/> tags = map(string)<br/> })</pre> | n/a | yes |
 | <a name="input_create_base_path_mapping"></a> [create_base_path_mapping](#input_create_base_path_mapping) | Whether to create a base path mapping for the custom domain | `bool` | `true` | no |
 | <a name="input_domain_name"></a> [domain_name](#input_domain_name) | Custom domain name for the API Gateway | `string` | `null` | no |
 | <a name="input_enabled"></a> [enabled](#input_enabled) | Whether to enable a custom domain name for the API Gateway | `bool` | `false` | no |
+| <a name="input_endpoint_access_mode"></a> [endpoint_access_mode](#input_endpoint_access_mode) | Endpoint access mode for the custom domain. Required when `security_policy` is an enhanced `SecurityPolicy_*` policy. Valid values: BASIC, STRICT. | `string` | `null` | no |
 | <a name="input_endpoint_type"></a> [endpoint_type](#input_endpoint_type) | Endpoint type for the domain name. Valid values: EDGE, REGIONAL | `string` | `"REGIONAL"` | no |
 | <a name="input_name"></a> [name](#input_name) | A descriptive but short name used for labels by the 'bendoerr-terraform-modules/terraform-null-label' module. | `string` | `"thing"` | no |
-| <a name="input_security_policy"></a> [security_policy](#input_security_policy) | TLS security policy for the custom domain. Valid values: TLS_1_0, TLS_1_2 | `string` | `"TLS_1_2"` | no |
+| <a name="input_security_policy"></a> [security_policy](#input_security_policy) | TLS security policy for the custom domain. Valid values include legacy `TLS_1_0`, `TLS_1_2`, and enhanced `SecurityPolicy_*` policies. See <https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-security-policies-list.html> | `string` | `"TLS_1_2"` | no |
 | <a name="input_stage_name"></a> [stage_name](#input_stage_name) | Name of the API Gateway stage | `string` | n/a | yes |
 
 ### Outputs

--- a/modules/custom-domain/main.tf
+++ b/modules/custom-domain/main.tf
@@ -14,7 +14,8 @@ resource "aws_api_gateway_domain_name" "this" {
   regional_certificate_arn = var.certificate_type == "REGIONAL" ? var.certificate_arn : null
   certificate_arn          = var.certificate_type == "EDGE" ? var.certificate_arn : null
 
-  security_policy = var.security_policy
+  security_policy      = var.security_policy
+  endpoint_access_mode = var.endpoint_access_mode
   endpoint_configuration {
     types = [var.endpoint_type]
   }

--- a/modules/custom-domain/variables.tf
+++ b/modules/custom-domain/variables.tf
@@ -53,8 +53,18 @@ variable "certificate_arn" {
 
 variable "security_policy" {
   type        = string
-  description = "TLS security policy for the custom domain. Valid values: TLS_1_0, TLS_1_2"
+  description = "TLS security policy for the custom domain. Valid values include legacy `TLS_1_0`, `TLS_1_2`, and enhanced `SecurityPolicy_*` policies. See https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-security-policies-list.html"
   default     = "TLS_1_2"
+}
+
+variable "endpoint_access_mode" {
+  type        = string
+  description = "Endpoint access mode for the custom domain. Required when `security_policy` is an enhanced `SecurityPolicy_*` policy. Valid values: BASIC, STRICT."
+  default     = null
+  validation {
+    condition     = var.endpoint_access_mode == null || contains(["BASIC", "STRICT"], coalesce(var.endpoint_access_mode, "BASIC"))
+    error_message = "Valid values for endpoint_access_mode are BASIC, STRICT, or null."
+  }
 }
 
 variable "endpoint_type" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated AWS provider requirement from 5.96.0 to 6.0.0.
* Enhanced security policy documentation to support advanced SecurityPolicy_* policies.

## New Features

* Added configurable `endpoint_access_mode` option for custom domain endpoints, supporting BASIC and STRICT access modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bendoerr-terraform-modules/terraform-aws-apigateway/pull/63)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->