### PR TITLE
✨ variables: add validation rules (closes #27)

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -44,6 +44,17 @@ variable "endpoint_configuration" {
   default = {
     types = ["EDGE"]
   }
+  nullable = false
+
+  validation {
+    condition     = length(var.endpoint_configuration.types) == 1
+    error_message = "endpoint_configuration.types must contain exactly one value — AWS API Gateway supports a single endpoint type per REST API."
+  }
+
+  validation {
+    condition     = alltrue([for t in var.endpoint_configuration.types : contains(["EDGE", "REGIONAL", "PRIVATE"], t)])
+    error_message = "endpoint_configuration.types may only contain \"EDGE\", \"REGIONAL\", or \"PRIVATE\"."
+  }
 }
 
 variable "stage_config" {
@@ -81,6 +92,22 @@ variable "logging_config" {
   description = "CloudWatch logging configuration for API Gateway access and execution logs."
   default     = {}
   nullable    = false
+
+  validation {
+    condition = contains(
+      [0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653],
+      var.logging_config.access_logs.retention_in_days
+    )
+    error_message = "logging_config.access_logs.retention_in_days must be a valid CloudWatch Logs retention value (0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, or 3653). 0 means never expire."
+  }
+
+  validation {
+    condition = contains(
+      [0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653],
+      var.logging_config.execution_logs.retention_in_days
+    )
+    error_message = "logging_config.execution_logs.retention_in_days must be a valid CloudWatch Logs retention value (0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, or 3653). 0 means never expire."
+  }
 }
 
 variable "method_settings" {
@@ -110,5 +137,45 @@ variable "method_settings" {
       require_authorization_for_cache_control    = true
       unauthorized_cache_control_header_strategy = "SUCCEED_WITH_RESPONSE_HEADER"
     }
+  }
+
+  validation {
+    condition = alltrue([
+      for path, s in var.method_settings :
+      s.logging_level == null || contains(["OFF", "ERROR", "INFO"], s.logging_level)
+    ])
+    error_message = "method_settings: logging_level must be one of \"OFF\", \"ERROR\", or \"INFO\"."
+  }
+
+  validation {
+    condition = alltrue([
+      for path, s in var.method_settings :
+      s.unauthorized_cache_control_header_strategy == null || contains(["FAIL_WITH_403", "SUCCEED_WITH_RESPONSE_HEADER", "SUCCEED_WITHOUT_RESPONSE_HEADER"], s.unauthorized_cache_control_header_strategy)
+    ])
+    error_message = "method_settings: unauthorized_cache_control_header_strategy must be one of \"FAIL_WITH_403\", \"SUCCEED_WITH_RESPONSE_HEADER\", or \"SUCCEED_WITHOUT_RESPONSE_HEADER\"."
+  }
+
+  validation {
+    condition = alltrue([
+      for path, s in var.method_settings :
+      s.throttling_rate_limit == null || s.throttling_rate_limit == -1 || s.throttling_rate_limit >= 0
+    ])
+    error_message = "method_settings: throttling_rate_limit must be -1 (throttling disabled) or a non-negative number."
+  }
+
+  validation {
+    condition = alltrue([
+      for path, s in var.method_settings :
+      s.throttling_burst_limit == null || s.throttling_burst_limit == -1 || s.throttling_burst_limit >= 0
+    ])
+    error_message = "method_settings: throttling_burst_limit must be -1 (throttling disabled) or a non-negative integer."
+  }
+
+  validation {
+    condition = alltrue([
+      for path, s in var.method_settings :
+      s.cache_ttl_in_seconds == null || (s.cache_ttl_in_seconds >= 0 && s.cache_ttl_in_seconds <= 3600)
+    ])
+    error_message = "method_settings: cache_ttl_in_seconds must be between 0 and 3600 seconds (the API Gateway cache TTL maximum)."
   }
 }


### PR DESCRIPTION
Closes #27.

Adds fail-fast variable validation so config mistakes surface at `terraform plan` with a clear message, instead of mid-`apply` as an opaque AWS API error.

## What's validated

| variable | rule |
|---|---|
| `endpoint_configuration.types` | exactly **one** of `EDGE` / `REGIONAL` / `PRIVATE` (AWS supports a single endpoint type per REST API) |
| `logging_config.access_logs.retention_in_days` | valid CloudWatch Logs retention enum (`0` = never expire) |
| `logging_config.execution_logs.retention_in_days` | same enum |
| `method_settings.*.logging_level` | `OFF` / `ERROR` / `INFO` |
| `method_settings.*.unauthorized_cache_control_header_strategy` | `FAIL_WITH_403` / `SUCCEED_WITH_RESPONSE_HEADER` / `SUCCEED_WITHOUT_RESPONSE_HEADER` |
| `method_settings.*.throttling_rate_limit` | `-1` (disabled) **or** `>= 0` |
| `method_settings.*.throttling_burst_limit` | `-1` (disabled) **or** `>= 0` |
| `method_settings.*.cache_ttl_in_seconds` | `0..3600` (APIGW cache max) |

## Notes / deviations from the issue body
The issue (#27) was filed against an older variable shape and a couple of its suggested bounds were **wrong** — I verified every constraint against the live AWS provider docs instead:
- **throttling**: the issue proposed `0.01..10000`. Reality: the provider uses **`-1` as the "throttling disabled" sentinel** (rejected by that range), and account-level rate limits can be raised **above** 10000 (so a hard upper cap would reject legitimate config). I honor `-1` and impose no bogus ceiling.
- **`cache_cluster_size`** already has its validation upstream — left as-is.
- `method_settings` enum/throttle checks are **null-guarded** because `optional()` keys can be explicitly `null` ("unset"), which AWS treats as valid.
- Added `nullable = false` to `endpoint_configuration` because `main.tf` dereferences `.types` unconditionally — null already crashes; this just fails fast with a clear message (matches `stage_config`'s house style).

## Testing
Every rule exercised **positive + negative** in a standalone harness (23 cases, all green): all example values (`retention=14`, default `EDGE`, default `method_settings`), both `-1` sentinels, raised limits, empty `method_settings` map → accept; two endpoint types, retention `10`/`999`, `logging_level=DEBUG`, bogus strategy, `ttl=3601`, negative throttle ≠ -1 → reject. `terraform fmt` clean, full `terraform validate` Success. README untouched (validation blocks don't render in terraform-docs tables).

@oldmanbendobot — your module, your button. eyes when you've got a sec? ♡ 🐱

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter validation for API Gateway configuration values.
  * Improved checks for endpoint type selection, logging retention settings, and method-level options.
  * Configurations with unsupported or out-of-range values will now fail fast with clearer feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->