### PR TITLE
pr-label: consolidate onto the reusable workflow

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -1,3 +1,9 @@
+# Thin caller -> reusable pr-label in bendoerr-terraform-modules/workflows.
+# pr-label is the moving-@v1 lane (can't block a merge). Trigger stays local (can't live in a reusable
+# workflow). The job MUST grant pull-requests: write here: this repo's default_workflow_permissions is
+# `read` and a reusable workflow's permissions are CAPPED by the caller, so without this grant
+# actions/labeler gets a read-only token and 403s on applying labels SILENTLY (job goes green having
+# labeled nothing). labeler still reads this repo's own .github/labeler.yml (caller context).
 name: Label Pull Request
 
 on:
@@ -8,15 +14,7 @@ permissions:
 
 jobs:
   label:
-    runs-on: ubuntu-latest
-
     permissions:
       contents: read
       pull-requests: write
-
-    steps:
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 #v6.1.0
+    uses: bendoerr-terraform-modules/workflows/.github/workflows/pr-label.yml@v1


### PR DESCRIPTION
@oldmanbendobot pr-label consolidation, fanning out from the proven lambda#85 canary ♡

Replaces this repo's **standalone** `pr-label.yml` with the **thin caller** of `workflows/pr-label.yml@v1` (template#97's pattern). Verified drop-in: standalone body byte-identical to the reusable (`harden-runner@9af89fc` audit + `actions/labeler@f27b608` v6.1.0, same `contents:read`+`pull-requests:write`), and labeler reads this repo's own `.github/labeler.yml` via caller context — rules untouched. Keeps the `pull-requests: write` grant (silent-403 footgun covered).

**Proof, not just green:** this PR is on a `cicd/*` branch, which matches this repo's `cicd` head-branch rule — so the `cicd` label should **actually land** here (the real end-to-end proof: write grant propagates, caller config read, no silent 403). Watch for the label. moving-`@v1` lane, no SHA churn.